### PR TITLE
Add VXI11.2 and UI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ This project is licensed under the GPL V3. See the [LICENSE](LICENSE) file for d
 ## Acknowledgements
 
 - A huge thanks to the [AR488 project](https://github.com/Twilight-Logic/AR488), run by [Twilight-Logic](https://github.com/Twilight-Logic) and its community contributors. The current software is a fork of AR488. For more information about this, see [here](SW/README.md).
+- The VXI-11 driver is partially inherited from [espBode](https://github.com/awakephd/espBode), and went through various evolutions before arriving here.


### PR DESCRIPTION
The main problems might be:

* testing with other tools, I only tested with lxi-tools and pyVisa
* other read configurations: I do the equivalent of '++read eoi'. That might not go with all instruments.

Watch out for the limitation of 4 to 6 instruments addressed when on VXI-11 (depending on if you use the web server). You can have more connected physically, it's the number of client connections that is limited.